### PR TITLE
Return undefined on non-existent deep keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ module.exports = function(obj, path, value, remove){
     if(typeof value !== 'undefined' && typeof obj[path[i]] === 'undefined'){
       obj[path[i]] = {};
     }
+    else if (!obj.hasOwnProperty(path[i])) {
+	return undefined;
+    }
     obj = obj[path[i]];
   }
 

--- a/test.js
+++ b/test.js
@@ -36,6 +36,18 @@ describe('getting values returns correct key value', function () {
   });
 });
 
+describe('getting non-existent values return undefined', function () {
+  it('shallow values', function () {
+    assert.equal(deepval(test, 'z'), undefined, 'shallow undefined get');
+  });
+  it('middle deep values', function () {
+    assert.equal(deepval(test, 'a.e.c'), undefined, 'deep undefined get');
+  });
+  it('end deep values', function () {
+    assert.equal(deepval(test, 'a.b.d'), undefined, 'end deep undefined get');
+  });
+});
+
 describe('setting values sets correct value', function () {
   it('shallow set', function () {
     assert.equal(deepval(test, 'foo', 'voo'), testExpected.foo, 'shallow value set');


### PR DESCRIPTION
The default behavior was to throw a 'TypeError: Cannot read property X of undefined' when a deep object does not exist to check on. This patch checks to see if the object has a property for the specified deep key and if not immediately returns undefined instead of attempting to move to the next level of the deep key.

I'm not sure if this is behavior you are willing to accept in this module, but this is one thing specifically that I was looking for in a deep key/value module... Not throwing errors when some part of a deep key does not exist on the inspected object.

Thanks for your work!
