### PR TITLE
Add ability to traverse getters/setters

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,18 @@
 'use strict';
 
-var deepval = function(obj, path, value, remove) {
+var hasOwn = Object.prototype.hasOwnProperty;
+var hasDeep = function(key) {
+  return !!(key && this[key]);
+};
+
+var deepval = function(obj, path, value, remove, ignoreOwn) {
   path = path.split('.');
   var pl = path.length - 1;
 
   for (var i = 0; i < pl; i += 1) {
     if (typeof value !== 'undefined' && typeof obj[path[i]] === 'undefined') {
       obj[path[i]] = {};
-    } else if (!obj.hasOwnProperty(path[i])) {
+    } else if (!(ignoreOwn ? hasDeep : hasOwn).call(obj, path[i])) {
       return undefined;
     }
     obj = obj[path[i]];
@@ -39,4 +44,8 @@ module.exports.del = function(obj, path) {
 
 module.exports.dotpath = function() {
   return Array.prototype.slice.call(arguments).join('.');
+};
+
+module.exports.deep = function(obj, path, value, remove) {
+  return deepval(obj, path, value, remove, true);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepval",
-  "version": "2.1.0",
+  "version": "2.1.1-pre",
   "description": "get and set object values using dot-delimited key strings",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -38,6 +38,19 @@ var expect = {
   ]
 };
 
+var deepData = function() {
+  this._key = 'test';
+};
+deepData.prototype = {
+  constructor: deepData,
+  get key() {
+    return this._key;
+  },
+  set key(k) {
+    this._key = k;
+  }
+};
+
 test('getting values returns correct key value', function(t) {
   t.plan(4);
   t.equal(deepval(data, 'foo'), 'bar', 'shallow value get');
@@ -110,9 +123,27 @@ test('can remove values via .del', function(t) {
 });
 
 test('provides a utlity function to join variables as a dotpath', function(t) {
-  t.plan(1)
+  t.plan(1);
   var a = 'hello';
   var b = 'test';
   deepval.dotpath(a, 'world', b);
   t.equal(deepval.dotpath(a, 'world', b), 'hello.world.test', 'dotpath is created correctly');
+});
+
+test('getting deep values (follow chain) values via .deep returns correct key value', function(t) {
+  t.plan(2);
+  var a = {
+    b: new deepData()
+  };
+  t.equal(deepval(a, 'b.key', undefined, false, true), 'test', 'getting values through getters works with flag');
+  t.equal(deepval.deep(a, 'b.key'), 'test', 'getting values through getters works');
+});
+
+test('setting deep values via .deep sets correct value', function(t) {
+  t.plan(2);
+  var a = {
+    b: new deepData()
+  };
+  t.equal(deepval.deep(a, 'b.key', 'deepset'), a.b.key, 'setting values through setters works');
+  t.equal(deepval.deep(a, 'b.key'), 'deepset', 'setting values through setters returns correct value');
 });


### PR DESCRIPTION
Small modification to allow the ability to do simple key checking instead of `hasOwnProperty` as this fails with getters/setters defined on the prototype. Does not change default behavior; tests are included
