### PR TITLE
Return undefined if a child node is undefined before reaching the desired node

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var deepval = function(obj, path, value, remove) {
   for (var i = 0; i < pl; i += 1) {
     if (typeof value !== 'undefined' && typeof obj[path[i]] === 'undefined') {
       obj[path[i]] = {};
-    } else if (!obj.hasOwnProperty(path[i])) {
+    } else if (!obj.hasOwnProperty(path[i]) || typeof obj[path[i]] === 'undefined') {
       return undefined;
     }
     obj = obj[path[i]];


### PR DESCRIPTION
Happy New Year Matt!

I hope you are doing well.
I noticed a bug on your package, in the following case:
```
var obj = {
  a: undefined
};

// get a value
console.log(deepval(obj, 'a.b.c'));   // 'deep'

// throw
/Users/thibautdelille/Projects/test/deepval-test/node_modules/deepval/index.js:10
    } else if (!obj.hasOwnProperty(path[i]) ) {
                   ^

TypeError: Cannot read property 'hasOwnProperty' of undefined
    at deepval (/Users/thibautdelille/Projects/test/deepval-test/node_modules/deepval/index.js:10:20)
    at Object.<anonymous> (/Users/thibautdelille/Projects/test/deepval-test/index.js:10:13)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)
    at startup (node.js:139:18)
    at node.js:968:3
```

to fix it I added a condition that return `undefined` if the value of the node is `undefined`.

Thanks for taking the time to review this :)

Thibaut

