### PR TITLE
Avoid throwing on bad data. Return undefined instead.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,29 +1,37 @@
 'use strict';
 
 var deepval = function(obj, path, value, remove) {
+  if (!obj) { // avoid throwing on a bad obj. just return undefined.
+    return undefined;
+  }
+
   if (!Array.isArray(path)) {
     path = path.split('.');
   }
   var pl = path.length - 1;
 
   for (var i = 0; i < pl; i += 1) {
-    if (typeof value !== 'undefined' && typeof obj[path[i]] === 'undefined') {
-      obj[path[i]] = {};
-    } else if (!obj.hasOwnProperty(path[i]) || typeof obj[path[i]] === 'undefined') {
+    var key = path[i];
+    var pathIsNullOrUndefined = isNullOrUndefined(obj[key]);
+    if (value !== undefined && pathIsNullOrUndefined) {
+      obj[key] = {};
+    } else if (!obj.hasOwnProperty(path[i]) || pathIsNullOrUndefined) {
       return undefined;
     }
     obj = obj[path[i]];
   }
 
-  if (typeof value !== 'undefined') {
-    if (remove) {
-      return delete obj[path[pl]];
-    } else {
-      obj[path[pl]] = value;
-    }
+  if (remove) {
+    return delete obj[path[pl]];
+  } else if (value !== undefined) { // allow setting a value to null
+    obj[path[pl]] = value;
   }
   return obj[path[pl]];
 };
+
+function isNullOrUndefined(val) {
+  return val === undefined || val === null;
+}
 
 module.exports = deepval;
 

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,9 @@ var deepval = require('..');
 
 var data = {
   foo: 'bar',
+  baz: {
+    qux: 'quux'
+  },
   a: {
     b: {
       c: 'deep'
@@ -18,6 +21,7 @@ var data = {
 
 var expect = {
   foo: 'voo',
+  _null: null,
   a: {
     b: {
       c: 'voo',
@@ -38,6 +42,14 @@ var expect = {
     ['zzz']
   ]
 };
+
+test('does not throw with bad/missing data', function(t) {
+  t.plan(4);
+  t.equal(deepval(undefined, 'foo'), undefined, 'undefined obj');
+  t.equal(deepval(data, 'bar'), undefined, 'missing key');
+  t.equal(deepval(data, 'bar.baz'), undefined, 'missing deeper key');
+  t.equal(deepval(data, 'bar.baz.qux'), undefined, 'missing still deeper key');
+});
 
 test('getting values returns correct key value', function(t) {
   t.plan(5);
@@ -101,16 +113,31 @@ test('can set deep values that are empty', function(t) {
   t.equal(deepval(data, 'g.empty', 'ok'), expect.g.empty, 'deep value set empty');
 });
 
+test('can set values to null', function(t) {
+  t.plan(2);
+  t.equal(deepval(data, 'j', null), expect._null, 'value set to null');
+  t.equal(deepval(data, 'k.l', null), expect._null, 'deeper value set to null');
+});
+
 test('can remove values', function(t) {
   t.plan(1);
   deepval(data, 'foo', null, true);
   t.equal(deepval(data, 'foo'), undefined, 'value is undefined');
 });
 
+test('can remove deep values', function(t) {
+  t.plan(2);
+  deepval(data, 'a.b', null, true);
+  t.equal(deepval(data, 'a.b'), undefined, 'value is undefined');
+  t.equal(deepval(data, 'not.here.at.all'), undefined, 'bad path returns undefined');
+});
+
 test('can remove values via .del', function(t) {
-  t.plan(1);
+  t.plan(2);
   deepval.del(data, 'foo');
+  deepval.del(data, 'bar.baz');
   t.equal(deepval.get(data, 'foo'), undefined, 'value is undefined');
+  t.equal(deepval.get(data, 'foo.bar'), undefined, 'deep value is undefined');
 });
 
 test('provides a utlity function to join variables as a dotpath', function(t) {


### PR DESCRIPTION
This was throwing when the initial object passed in is `undefined`.
```js
deepval(undefinedVariable, 'a.b.c');
```
And is also throwing when a key in path is `null`. For instance if `file` is `null` in:
```js
deepval(objectWithMostlyValidData, 'image.file.key');
```
In both cases, `undefined` is returned with this change.